### PR TITLE
feat: add etsiunitinfo to identifiy entries belongig to same device

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ func main() {
 	flag.StringVar(&freepsConfig.Address, "h", "fritz.box", "Address of your FritzBox")
 	flag.StringVar(&freepsConfig.Password, "p", "", "Password")
 	flag.StringVar(&freepsConfig.User, "u", "", "User")
+	freepsConfig.Verbose = true
 
 	service := flag.String("s", "Hosts", "Service to call")
 	action := flag.String("a", "X_AVM-DE_GetSpecificHostEntryByIP", "Action to call")

--- a/freepslib.go
+++ b/freepslib.go
@@ -350,9 +350,16 @@ type AvmButton struct {
 	LastPressedTimestamp int     `xml:"lastpressedtimestamp"`
 }
 
+type AvmEtsiUnitInfo struct {
+	DeviceID   int    `xml:"etsideviceid"`
+	UnitType   int    `xml:"unittype"`
+	Interfaces string `xml:"interfaces"`
+}
+
 type AvmDevice struct {
 	Name         string                 `xml:"name" json:",omitempty"`
 	AIN          string                 `xml:"identifier,attr"`
+	DeviceID     string                 `xml:"id,attr"`
 	ProductName  string                 `xml:"productname,attr" json:",omitempty"`
 	Present      bool                   `xml:"present" json:",omitempty"`
 	Switch       *AvmDeviceSwitch       `xml:"switch" json:",omitempty"`
@@ -364,6 +371,7 @@ type AvmDevice struct {
 	HKR          *AvmDeviceHkr          `xml:"hkr" json:",omitempty"`
 	Alert        *AvmDeviceAlert        `xml:"alert" json:",omitempty"`
 	Button       *AvmButton             `xml:"button" json:",omitempty"`
+	EtsiUnitInfo *AvmEtsiUnitInfo       `xml:"etsiunitinfo" json:",omitempty"`
 }
 
 type AvmDeviceList struct {


### PR DESCRIPTION
Devices with multiple Buttons or Functions have multiple AINs. The identifier is the same for all of them