### PR TITLE
fix: same etsi id type everywhere

### DIFF
--- a/freepslib.go
+++ b/freepslib.go
@@ -351,7 +351,7 @@ type AvmButton struct {
 }
 
 type AvmEtsiUnitInfo struct {
-	DeviceID   int    `xml:"etsideviceid"`
+	DeviceID   string `xml:"etsideviceid"`
 	UnitType   int    `xml:"unittype"`
 	Interfaces string `xml:"interfaces"`
 }


### PR DESCRIPTION
ETSI device ID is not necessarily a number (although it always appears to be one). Use string to be save